### PR TITLE
issue #3 correction

### DIFF
--- a/keymaps/auto-id-class.cson
+++ b/keymaps/auto-id-class.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
-'atom-text-editor':
+'atom-text-editor:not([mini])':
   '#': 'auto-id-class:insert_id_attribute'
   '.': 'auto-id-class:insert_class_attribute'


### PR DESCRIPTION
Correction of the following problem:
Cursor in tag will output class/id though search/cmd+p dialog has focus #3
To simulate: place cursor within an html tag and then use cmd+p and type a . this will output class="" into the previously selected html tag even though it's not in focus.